### PR TITLE
Added directory checks and installation of python3-pip

### DIFF
--- a/c_desktop.py
+++ b/c_desktop.py
@@ -10,7 +10,12 @@ print(dir_path)
 f_content = "[Desktop Entry]\nName=Twister UI Patcher\nComment=Updates Twister UI\nExec="+dir_path+"/src/start.sh\nIcon="+dir_path+"/src/icon.png\nCategories=System;\nVersion=1.0.0\nType=Application\nTerminal=false\nStartupNotify=true"
 print(f_content)
 
-x_dir = home_path+"/.local/share/applications/patcher.desktop"
+app_dir = home_path+"/.local/share/applications"
+x_dir = app_dir+"/patcher.desktop"
+
+if not os.path.isdir(app_dir):
+    os.mkdir(app_dir)
+
 print("Saved menu shortcut to %s" % x_dir)
 f2 = open(x_dir, "w+")
 f2.write(f_content)

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ echo Checking for tkinter: $problem
 if [ "" == "$problem" ]; then
 	sudo apt-get install python3-tk
 fi
-sudo apt install -y python3-pil python3-pil.imagetk
+sudo apt install -y python3-pil python3-pil.imagetk python3-pip
 sudo pip3 install wget
 #Get archive from github and unzip it
 cd ${HOME}


### PR DESCRIPTION
- For some reason my Xubuntu 20.04.1 LTS does not come with "~/.local/share/applications". As a result the python script will always fail. Added an if statement to check and create if not exists.
- `python3-pip` is not installed by default. Added `python3-pip` to list of `apt install` applications